### PR TITLE
Make template a parameter to create & valid? methods.

### DIFF
--- a/lib/stackup/stack.rb
+++ b/lib/stackup/stack.rb
@@ -3,20 +3,19 @@ require "set"
 module Stackup
   class Stack
 
-    attr_reader :stack, :name, :cf, :template, :monitor
+    attr_reader :stack, :name, :cf, :monitor
     SUCESS_STATES = ["CREATE_COMPLETE", "UPDATE_COMPLETE"]
     FAILURE_STATES = ["CREATE_FAILED", "DELETE_COMPLETE", "DELETE_FAILED", "UPDATE_ROLLBACK_FAILED", "ROLLBACK_FAILED", "ROLLBACK_COMPLETE", "ROLLBACK_FAILED", "UPDATE_ROLLBACK_COMPLETE", "UPDATE_ROLLBACK_FAILED"]
     END_STATES = SUCESS_STATES + FAILURE_STATES
 
-    def initialize(name, template)
+    def initialize(name)
       @cf = Aws::CloudFormation::Client.new
       @stack = Aws::CloudFormation::Stack.new(:name => name, :client => cf)
       @monitor = Stackup::Monitor.new(@stack)
-      @template = template
       @name = name
     end
 
-    def create
+    def create(template)
       response = cf.create_stack(:stack_name => name,
                                  :template_body => template,
                                  :disable_rollback => true)
@@ -45,7 +44,7 @@ module Stackup
       false
     end
 
-    def valid?
+    def valid?(template)
       response = cf.validate_template(template)
       response[:code].nil?
     end

--- a/spec/stackup/monitor_spec.rb
+++ b/spec/stackup/monitor_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe Stackup::Monitor do
-  let(:stack) { Stackup::Stack.new("name", "template") }
+  let(:stack) { Stackup::Stack.new("name") }
   let(:monitor) { Stackup::Monitor.new(stack) }
   let(:event) { double(Aws::CloudFormation::Event.new(:id => "1")) }
   let(:events) { [event] }

--- a/spec/stackup/stack_spec.rb
+++ b/spec/stackup/stack_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
 
 describe Stackup::Stack do
-  let(:stack) { Stackup::Stack.new("stack_name", double(String)) }
+  let(:stack) { Stackup::Stack.new("stack_name") }
+  let(:template) { double(String) }
   let(:cf_stack) { double(Aws::CloudFormation::Stack) }
   let(:cf) { double(Aws::CloudFormation::Client) }
 
@@ -25,26 +26,26 @@ describe Stackup::Stack do
       allow(response).to receive(:[]).with(:stack_id).and_return("1")
       allow(cf).to receive(:create_stack).and_return(response)
       allow(cf_stack).to receive(:wait_until).and_return(true)
-      expect(stack.create).to be true
+      expect(stack.create(template)).to be true
     end
 
     it "should return nil if stack was not created" do
       allow(response).to receive(:[]).with(:stack_id).and_return(nil)
       allow(cf).to receive(:create_stack).and_return(response)
       allow(cf_stack).to receive(:wait_until).and_return(false)
-      expect(stack.create).to be false
+      expect(stack.create(template)).to be false
     end
   end
 
   context "validate" do
     it "should be valid if cf validate say so" do
       allow(cf).to receive(:validate_template).and_return({})
-      expect(stack.valid?).to be true
+      expect(stack.valid?(template)).to be true
     end
 
     it "should be invalid if cf validate say so" do
       allow(cf).to receive(:validate_template).and_return(:code => "404")
-      expect(stack.valid?).to be false
+      expect(stack.valid?(template)).to be false
     end
 
   end

--- a/stackup.gemspec
+++ b/stackup.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 Gem::Specification.new do |spec|
 
   spec.name          = "stackup"
-  spec.version       = "0.0.2"
+  spec.version       = "0.0.3"
   spec.authors       = ["Arvind Kunday", "Mike Williams"]
   spec.email         = ["arvind.kunday@rea-group.com", "mike.williams@rea-group.com"]
   spec.summary       = "Tools for deployment to AWS"


### PR DESCRIPTION
Removed Stack from the responsibility of holding the stack
template, and stack can be just be a wrapper around the ruby
aws sdk.

This also frees from passing the template file to the stack.delete
because it made no sense.

Based on feedback by @mdub