### PR TITLE
Add stack outputs as a rake task

### DIFF
--- a/lib/stackup/rake_tasks.rb
+++ b/lib/stackup/rake_tasks.rb
@@ -61,6 +61,11 @@ module Stackup
           stackup "inspect"
         end
 
+        desc "Show #{stack} stack outputs only"
+        task "outputs" do
+          stackup "outputs"
+        end
+
         desc "Delete #{stack} stack"
         task "down" do
           stackup "down"


### PR DESCRIPTION
I use the stack outputs as part my workflow, this is just a handy way instead of either going to the shell or parsing the inspect output.