### PR TITLE
Fix diff by providing a diff tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM ruby:2.3-alpine
 
 MAINTAINER https://github.com/realestate-com-au/stackup
 
+RUN apk --no-cache add diffutils
+
 WORKDIR /app
 
 COPY bin /app/bin


### PR DESCRIPTION
The diff command prints nothing presently. Adding `diffutils` brings us the desired behavior.