### PR TITLE
Relax dependency version on `diffy`

### DIFF
--- a/stackup.gemspec
+++ b/stackup.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk-resources", "~> 2.0"
   spec.add_dependency "clamp", "~> 1.0"
   spec.add_dependency "console_logger"
-  spec.add_dependency "diffy", "~> 3.0.5"
+  spec.add_dependency "diffy", "~> 3.0"
   spec.add_dependency "multi_json"
 
 end


### PR DESCRIPTION
Having a patch version specified for diffy (`~>3.0.9`) limits the ability to use a later minor version (`3.1`).
This is required for compatibility with other Rubygems that specify a later version of `diffy`.