### PR TITLE
Support CloudFormation YAML extensions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## PENDING
+
+* Add support for CloudFormation YAML extensions (e.g. `!Ref`).
+
 ## 0.9.5 (2016-09-26)
 
 * Add `--with-role` option, to assume a role for stack operations.

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ Called with `--list`, it will list stacks:
     foo-bar-test
     zzz-production
 
-The command-line support inputs (template and parameters) in either JSON or YAML format.
-
 ### Stack create/update
 
 Use sub-command "up" to create or update a stack, as appropriate:
@@ -101,6 +99,12 @@ Parameters and tags may be specified via files, or as a Hash, e.g.
       t.parameters = "production-params.json"
       t.tags = { "environment" => "production" }
     end
+
+## YAML support
+
+Stackup supports input files (template, parameters, tags) in either JSON or YAML format.
+
+It also supports the [abbreviated YAML syntax for Cloudformation functions](https://aws.amazon.com/blogs/aws/aws-cloudformation-update-yaml-cross-stack-references-simplified-substitution/), though unlike the [AWS CLI](https://aws.amazon.com/cli/), Stackup normalises YAML input to JSON before invoking CloudFormation APIs.
 
 ## Docker image
 

--- a/bin/stackup
+++ b/bin/stackup
@@ -9,7 +9,7 @@ require "securerandom"
 require "stackup"
 require "stackup/differ"
 require "stackup/version"
-require "yaml"
+require "stackup/yaml"
 
 $stdout.sync = true
 $stderr.sync = true
@@ -127,7 +127,7 @@ Clamp do
   end
 
   def load_data(file)
-    YAML.load_file(file)
+    Stackup::YAML.load_file(file)
   rescue Errno::ENOENT
     signal_error "no such file: #{file.inspect}"
   end

--- a/examples/template.yml
+++ b/examples/template.yml
@@ -1,0 +1,33 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: AWS CloudFormation Sample Template
+Parameters:
+  IndexDoc:
+    Description: Website index doc
+    Type: String
+    Default: index.html
+Resources:
+  S3Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      AccessControl: PublicRead
+      WebsiteConfiguration:
+        IndexDocument:
+          Ref: IndexDoc
+        ErrorDocument: error.html
+Outputs:
+  WebsiteURL:
+    Value:
+      Fn::GetAtt:
+      - S3Bucket
+      - WebsiteURL
+    Description: URL for website hosted on S3
+  S3BucketSecureURL:
+    Value:
+      Fn::Join:
+      - ''
+      - - https://
+        - !GetAtt
+          - S3Bucket
+          - DomainName
+    Description: Name of S3 bucket to hold website content

--- a/lib/stackup/yaml.rb
+++ b/lib/stackup/yaml.rb
@@ -1,0 +1,61 @@
+require "yaml"
+
+module Stackup
+
+  # Modified YAML parsing, to support CloudFormation YAML shortcuts
+  #
+  module YAML
+
+    class << self
+
+      # Dump Ruby object +o+ to a YAML string.
+      #
+      def dump(*args)
+        ::YAML.dump(*args)
+      end
+
+      # Load YAML stream/string into a Ruby data structure.
+      #
+      # Supports CloudFormation extensions:
+      #
+      #   `!Ref blah` as a shortcut for `{ "Ref" => blah }`
+      #   `!Foo blah` as a shortcut for `{ "Fn::Foo" => blah }`
+      #
+      def load(yaml, filename = nil)
+        tree = ::YAML.parse(yaml, filename)
+        return tree unless tree
+        CloudFormationToRuby.create.accept(tree)
+      end
+
+      # Load YAML file into a Ruby data structure.
+      #
+      # Supports CloudFormation extensions as per `load`.
+      #
+      def load_file(filename)
+        File.open(filename, 'r:bom|utf-8') do |f|
+          load(f, filename)
+        end
+      end
+
+    end
+
+    # Custom Psych node visitor, with CloudFormation extensions.
+    #
+    class CloudFormationToRuby < Psych::Visitors::ToRuby
+
+      def accept(target)
+        case target.tag
+        when "!Ref"
+          { "Ref" => super }
+        when /^!(\w+)$/
+          { "Fn::#{$1}" => super }
+        else
+          super
+        end
+      end
+
+    end
+
+  end
+
+end

--- a/spec/stackup/yaml_spec.rb
+++ b/spec/stackup/yaml_spec.rb
@@ -1,0 +1,79 @@
+require "spec_helper"
+
+require "stackup/yaml"
+
+describe Stackup::YAML do
+
+  describe ".load" do
+
+    let(:data) do
+      described_class.load(input)
+    end
+
+    context "with plain YAML" do
+
+      let(:input) do
+        <<-YAML
+        Outputs:
+          Foo: "bar"
+        YAML
+      end
+
+      it "loads as normal" do
+        expect(data).to eql(
+          "Outputs" => {
+            "Foo" => "bar"
+          }
+        )
+      end
+
+    end
+
+    context "with a !Ref" do
+
+      let(:input) do
+        <<-YAML
+        Outputs:
+          Foo: !Ref "Bar"
+        YAML
+      end
+
+      it "expands to Ref" do
+        expect(data).to eql(
+          "Outputs" => {
+            "Foo" => {
+              "Ref" => "Bar"
+            }
+          }
+        )
+      end
+
+    end
+
+    context "with a !Ref" do
+
+      let(:input) do
+        <<-YAML
+        Outputs:
+          Foo: !GetAtt ["Bar", "Baz"]
+        YAML
+      end
+
+      it "expands to Ref" do
+        expect(data).to eql(
+          "Outputs" => {
+            "Foo" => {
+              "Fn::GetAtt" => [
+                "Bar",
+                "Baz"
+              ]
+            }
+          }
+        )
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
Addresses #31, via "Option B".

I've introduced a customised YAML parser, to mimic CloudFormation's built-in handling of YAML tags.
