### PR TITLE
adjusting parse_body to use inbuilt gem json.parse instead of regex

### DIFF
--- a/lib/stackup/source.rb
+++ b/lib/stackup/source.rb
@@ -29,8 +29,6 @@ module Stackup
 
     private
 
-    LOOKS_LIKE_JSON = /^\s*[\{\[]/
-
     def uri
       URI(location)
     end
@@ -52,11 +50,17 @@ module Stackup
     end
 
     def parse_body
-      if body =~ LOOKS_LIKE_JSON
-        MultiJson.load(body)
-      else
-        Stackup::YAML.load(body)
-      end
+        begin
+            JSON.parse(body)
+            type="json"
+          rescue JSON::ParserError
+            type="yaml"
+        end
+        if type == "json"
+            MultiJson.load(body)
+          elsif type == "yaml"
+            Stackup::YAML.load(body)
+        end
     end
 
     class ReadError < StandardError

--- a/lib/stackup/source.rb
+++ b/lib/stackup/source.rb
@@ -51,14 +51,8 @@ module Stackup
 
     def parse_body
         begin
-            JSON.parse(body)
-            type="json"
-          rescue JSON::ParserError
-            type="yaml"
-        end
-        if type == "json"
             MultiJson.load(body)
-          elsif type == "yaml"
+          rescue MultiJson::ParseError
             Stackup::YAML.load(body)
         end
     end

--- a/lib/stackup/version.rb
+++ b/lib/stackup/version.rb
@@ -1,5 +1,5 @@
 module Stackup
 
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 
 end


### PR DESCRIPTION
problems have been experienced when inputting yaml CFN templates into stackup, the logic within source.rb uses a regex match which seems to occasionally define valid yaml templates as json and breaks:
/usr/local/lib/ruby/2.3.0/json/common.rb:156:in `parse': 822: unexpected token at '--- (MultiJson::ParseError)

We've repeated the issue across multiple yaml based CFN templates, let me know if you want a sample non publicly.

The fix proposed is to use the inbuilt json gem parser to attempt to parse the input.
Ideally I wouldn't rely on an exception but I'm not sure of a more effective way.