### PR TITLE
Revert to regex for detection of JSON vs YAML

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 1.1.3 (PENDING)
+
+* Fix #39: parse error when JSON-like text is embedded in YAML.
+
 ## 1.1.1 (2017-02-23)
 
 * The `stackup` CLI now allows stack template and policy documents to be specified as URLs.

--- a/examples/template.json
+++ b/examples/template.json
@@ -1,3 +1,4 @@
+
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Description": "AWS CloudFormation Sample Template",

--- a/examples/template.yml
+++ b/examples/template.yml
@@ -15,6 +15,16 @@ Resources:
         IndexDocument:
           Ref: IndexDoc
         ErrorDocument: error.html
+  Whatever:
+    Type: Whatever
+    Properties:
+      Content: |
+        /etc/awslogs/awscli.conf:
+          content: !Sub: |
+              [default]
+              region = ${AWS::Region}
+              [plugins]
+              cwlogs = cwlogs
 Outputs:
   WebsiteURL:
     Value:

--- a/lib/stackup/source.rb
+++ b/lib/stackup/source.rb
@@ -53,6 +53,8 @@ module Stackup
 
     def parse_body
       if body =~ LOOKS_LIKE_JSON
+        # Psych has issues parsing some JSON, so let's use a JSON parser.
+        # (see https://github.com/realestate-com-au/stackup/issues/35)
         MultiJson.load(body)
       else
         Stackup::YAML.load(body)

--- a/lib/stackup/source.rb
+++ b/lib/stackup/source.rb
@@ -29,6 +29,8 @@ module Stackup
 
     private
 
+    LOOKS_LIKE_JSON = /^\s*[\{\[]/
+
     def uri
       URI(location)
     end
@@ -50,17 +52,11 @@ module Stackup
     end
 
     def parse_body
-        begin
-            JSON.parse(body)
-            type="json"
-          rescue JSON::ParserError
-            type="yaml"
-        end
-        if type == "json"
-            MultiJson.load(body)
-          elsif type == "yaml"
-            Stackup::YAML.load(body)
-        end
+      if body =~ LOOKS_LIKE_JSON
+        MultiJson.load(body)
+      else
+        Stackup::YAML.load(body)
+      end
     end
 
     class ReadError < StandardError

--- a/lib/stackup/source.rb
+++ b/lib/stackup/source.rb
@@ -51,8 +51,14 @@ module Stackup
 
     def parse_body
         begin
+            JSON.parse(body)
+            type="json"
+          rescue JSON::ParserError
+            type="yaml"
+        end
+        if type == "json"
             MultiJson.load(body)
-          rescue MultiJson::ParseError
+          elsif type == "yaml"
             Stackup::YAML.load(body)
         end
     end

--- a/lib/stackup/source.rb
+++ b/lib/stackup/source.rb
@@ -29,7 +29,7 @@ module Stackup
 
     private
 
-    LOOKS_LIKE_JSON = /^\s*[\{\[]/
+    LOOKS_LIKE_JSON = /\A\s*[\{\[]/
 
     def uri
       URI(location)

--- a/lib/stackup/version.rb
+++ b/lib/stackup/version.rb
@@ -1,5 +1,5 @@
 module Stackup
 
-  VERSION = "1.1.2"
+  VERSION = "1.1.1"
 
 end

--- a/lib/stackup/version.rb
+++ b/lib/stackup/version.rb
@@ -1,5 +1,5 @@
 module Stackup
 
-  VERSION = "1.1.1"
+  VERSION = "1.1.3"
 
 end


### PR DESCRIPTION
PR #41 (releases as version 1.1.2) modified the way we detect JSON vs YAML format to use exceptions; this PR goes back to the previous regex-based approach, as I'd rather avoid using exceptions for flow-control.

Basically, the original problem was caused because the regex matched a bit too much, but it was easy to fix. 

Fixes #39, reverts #41. Ping @lukeck, @nappa32, @lnunns.
