### PR TITLE
Add support for change-sets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 *.gem
 *.rbc
 .bundle
+.byebug_history
 .config
 .rbenv-*
 .ruby-version
+.rvmrc
 .yardoc
 Gemfile.lock
 InstalledFiles
@@ -17,4 +19,3 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
-.rvmrc

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## PENDING
+
+* Add support for change-sets.
+
 ## 1.1.3 (2017-05-01)
 
 * Fix #39: parse error when JSON-like text is embedded in YAML.

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org" do
+
   gemspec
 
   gem "rake", "~> 10.0"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ AWS CloudFormation stacks.
 	- [Using URLs as inputs](#using-urls-as-inputs)
 	- [Stack deletion](#stack-deletion)
 	- [Stack inspection](#stack-inspection)
+	- [Change-set support](#change-set-support)
 - [Programmatic usage](#programmatic-usage)
 - [Rake integration](#rake-integration)
 - [Docker image](#docker-image)
@@ -149,6 +150,17 @@ Inspect details of a stack with:
     $ stackup myapp-test status
     $ stackup myapp-test resources
     $ stackup myapp-test outputs
+
+### Change-set support
+
+You can also create, list, inspect, apply and delete [change sets](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-changesets.html) using `stackup`.
+
+    $ stackup myapp-test change-sets
+    $ stackup myapp-test change-set create -t template.json
+    $ stackup myapp-test change-set inspect
+    $ stackup myapp-test change-set apply
+
+The change-set name defaults to "pending", but can be overridden using `--name`.
 
 ## Programmatic usage
 

--- a/bin/stackup
+++ b/bin/stackup
@@ -129,16 +129,46 @@ Clamp do
     puts final_status unless final_status.nil?
   end
 
-  def parameters_from_files
-    parameter_sources.map { |src|
-      Stackup::Parameters.new(src.data).to_hash
-    }.inject({}, :merge)
-  end
-
   subcommand "status", "Print stack status." do
 
     def execute
       puts stack.status
+    end
+
+  end
+
+  module HasParameters
+
+    extend Clamp::Option::Declaration
+
+    option ["-p", "--parameters"], "FILE", "parameters file (last wins)",
+           :multivalued => true,
+           :attribute_name => :parameter_sources,
+           &Stackup::Source.method(:new)
+
+    option ["-o", "--override"], "PARAM=VALUE", "parameter overrides",
+           :multivalued => true,
+           :attribute_name => :override_list
+
+    private
+
+    def parameters
+      parameters_from_files.merge(parameter_overrides)
+    end
+
+    def parameters_from_files
+      parameter_sources.map { |src|
+        Stackup::Parameters.new(src.data).to_hash
+      }.inject({}, :merge)
+    end
+
+    def parameter_overrides
+      {}.tap do |result|
+        override_list.each do |override|
+          key, value = override.split("=", 2)
+          result[key] = value
+        end
+      end
     end
 
   end
@@ -152,14 +182,7 @@ Clamp do
     option ["-T", "--use-previous-template"], :flag,
            "reuse the existing template"
 
-    option ["-p", "--parameters"], "FILE", "parameters file (last wins)",
-           :multivalued => true,
-           :attribute_name => :parameter_sources,
-           &Stackup::Source.method(:new)
-
-    option ["-o", "--override"], "PARAM=VALUE", "parameter overrides",
-           :multivalued => true,
-           :attribute_name => :override_list
+    include HasParameters
 
     option "--tags", "FILE", "stack tags file",
            :attribute_name => :tag_source,
@@ -198,21 +221,6 @@ Clamp do
       options[:use_previous_template] = use_previous_template?
       report_change do
         stack.create_or_update(options)
-      end
-    end
-
-    private
-
-    def parameters
-      parameters_from_files.merge(parameter_overrides)
-    end
-
-    def parameter_overrides
-      {}.tap do |result|
-        override_list.each do |override|
-          key, value = override.split("=", 2)
-          result[key] = value
-        end
       end
     end
 
@@ -266,20 +274,17 @@ Clamp do
 
   subcommand "diff", "Compare template/params to current stack." do
 
+    option "--diff-format", "FORMAT", "'text', 'color', or 'html'", :default => "color"
+
     option ["-t", "--template"], "FILE", "template source",
            :attribute_name => :template_source,
            &Stackup::Source.method(:new)
 
-    option ["-p", "--parameters"], "FILE", "parameters file (last wins)",
-           :multivalued => true,
-           :attribute_name => :parameter_sources,
-           &Stackup::Source.method(:new)
+    include HasParameters
 
     option "--tags", "FILE", "stack tags file",
            :attribute_name => :tag_source,
            &Stackup::Source.method(:new)
-
-    option "--diff-format", "FORMAT", "'text', 'color', or 'html'", :default => "color"
 
     def execute
       current = {}
@@ -311,7 +316,7 @@ Clamp do
     end
 
     def new_parameters
-      existing_parameters.merge(parameters_from_files)
+      existing_parameters.merge(parameters)
     end
 
   end

--- a/bin/stackup
+++ b/bin/stackup
@@ -248,7 +248,9 @@ Clamp do
 
   subcommand ["change-set"], "Change-set operations." do
 
-    parameter "NAME", "Name of change-set", :attribute_name => :change_set_name
+    option "--name", "NAME", "Name of change-set",
+           :attribute_name => :change_set_name,
+           :default => "pending"
 
     subcommand "execute", "Apply the change-set." do
 

--- a/bin/stackup
+++ b/bin/stackup
@@ -252,6 +252,45 @@ Clamp do
            :attribute_name => :change_set_name,
            :default => "pending"
 
+    subcommand "create", "Create a change-set." do
+
+      option ["-d", "--description"], "DESC",
+             "Change-set description"
+
+      option ["-t", "--template"], "FILE", "template source",
+             :attribute_name => :template_source,
+             &Stackup::Source.method(:new)
+
+      option ["-T", "--use-previous-template"], :flag,
+             "reuse the existing template"
+
+      include HasParameters
+
+      option "--tags", "FILE", "stack tags file",
+             :attribute_name => :tag_source,
+             &Stackup::Source.method(:new)
+
+      def execute
+        unless template_source || use_previous_template?
+          signal_usage_error "Specify either --template or --use-previous-template"
+        end
+        options = {}
+        if template_source
+          if template_source.s3?
+            options[:template_url] = template_source.location
+          else
+            options[:template] = template_source.data
+          end
+        end
+        options[:parameters] = parameters
+        options[:description] = description if description
+        options[:tags] = tag_source.data if tag_source
+        options[:use_previous_template] = use_previous_template?
+        stack.create_change_set(change_set_name, options)
+      end
+
+    end
+
     subcommand "execute", "Apply the change-set." do
 
       def execute

--- a/bin/stackup
+++ b/bin/stackup
@@ -218,6 +218,33 @@ Clamp do
 
   end
 
+  subcommand ["change-sets"], "List change-sets." do
+
+    def execute
+      stack.change_set_summaries.each do |change_set|
+        puts [
+          pad(change_set.change_set_name, 36),
+          pad(change_set.status, 20),
+          pad(change_set.execution_status, 24)
+        ].join("  ")
+      end
+    end
+
+    private
+
+    def pad(s, width)
+      (s || "").ljust(width)
+    end
+
+  end
+
+  # subcommand ["change-set"], "Change-set operations." do
+  #
+  #   parameter "NAME", "Name of change-set", :attribute_name => :change_set_name
+  #
+  #
+  # end
+
   subcommand "diff", "Compare template/params to current stack." do
 
     option ["-t", "--template"], "FILE", "template source",

--- a/bin/stackup
+++ b/bin/stackup
@@ -313,7 +313,7 @@ Clamp do
 
     end
 
-    subcommand "execute", "Apply the change-set." do
+    subcommand ["apply", "execute"], "Apply the change-set." do
 
       def execute
         report_change do

--- a/bin/stackup
+++ b/bin/stackup
@@ -264,6 +264,9 @@ Clamp do
       option ["-T", "--use-previous-template"], :flag,
              "reuse the existing template"
 
+      option ["--force"], :flag,
+             "replace existing change-set of the same name"
+
       include HasParameters
 
       option "--tags", "FILE", "stack tags file",
@@ -286,6 +289,7 @@ Clamp do
         options[:description] = description if description
         options[:tags] = tag_source.data if tag_source
         options[:use_previous_template] = use_previous_template?
+        options[:force] = force?
         stack.change_set(change_set_name).create(options)
       end
 

--- a/bin/stackup
+++ b/bin/stackup
@@ -238,12 +238,21 @@ Clamp do
 
   end
 
-  # subcommand ["change-set"], "Change-set operations." do
-  #
-  #   parameter "NAME", "Name of change-set", :attribute_name => :change_set_name
-  #
-  #
-  # end
+  subcommand ["change-set"], "Change-set operations." do
+
+    parameter "NAME", "Name of change-set", :attribute_name => :change_set_name
+
+    subcommand "delete", "Delete the change-set." do
+
+      def execute
+        report_change do
+          stack.delete_change_set(change_set_name)
+        end
+      end
+
+    end
+
+  end
 
   subcommand "diff", "Compare template/params to current stack." do
 

--- a/bin/stackup
+++ b/bin/stackup
@@ -290,7 +290,9 @@ Clamp do
         options[:tags] = tag_source.data if tag_source
         options[:use_previous_template] = use_previous_template?
         options[:force] = force?
-        stack.change_set(change_set_name).create(options)
+        report_change do
+          stack.change_set(change_set_name).create(options)
+        end
       end
 
     end

--- a/bin/stackup
+++ b/bin/stackup
@@ -297,6 +297,22 @@ Clamp do
 
     end
 
+    subcommand "changes", "Describe the change-set." do
+
+      def execute
+        display_data(stack.change_set(change_set_name).describe.changes.map(&:to_h))
+      end
+
+    end
+
+    subcommand "inspect", "Show full change-set details." do
+
+      def execute
+        display_data(stack.change_set(change_set_name).describe.to_h)
+      end
+
+    end
+
     subcommand "execute", "Apply the change-set." do
 
       def execute

--- a/bin/stackup
+++ b/bin/stackup
@@ -286,7 +286,7 @@ Clamp do
         options[:description] = description if description
         options[:tags] = tag_source.data if tag_source
         options[:use_previous_template] = use_previous_template?
-        stack.create_change_set(change_set_name, options)
+        stack.change_set(change_set_name).create(options)
       end
 
     end

--- a/bin/stackup
+++ b/bin/stackup
@@ -291,7 +291,7 @@ Clamp do
         options[:use_previous_template] = use_previous_template?
         options[:force] = force?
         report_change do
-          stack.change_set(change_set_name).create(options)
+          change_set.create(options)
         end
       end
 
@@ -300,7 +300,7 @@ Clamp do
     subcommand "changes", "Describe the change-set." do
 
       def execute
-        display_data(stack.change_set(change_set_name).describe.changes.map(&:to_h))
+        display_data(change_set.describe.changes.map(&:to_h))
       end
 
     end
@@ -308,7 +308,7 @@ Clamp do
     subcommand "inspect", "Show full change-set details." do
 
       def execute
-        display_data(stack.change_set(change_set_name).describe.to_h)
+        display_data(change_set.describe.to_h)
       end
 
     end
@@ -317,7 +317,7 @@ Clamp do
 
       def execute
         report_change do
-          stack.execute_change_set(change_set_name)
+          change_set.execute
         end
       end
 
@@ -327,10 +327,16 @@ Clamp do
 
       def execute
         report_change do
-          stack.delete_change_set(change_set_name)
+          change_set.delete
         end
       end
 
+    end
+
+    private
+
+    def change_set
+      stack.change_set(change_set_name)
     end
 
   end

--- a/bin/stackup
+++ b/bin/stackup
@@ -242,6 +242,16 @@ Clamp do
 
     parameter "NAME", "Name of change-set", :attribute_name => :change_set_name
 
+    subcommand "execute", "Apply the change-set." do
+
+      def execute
+        report_change do
+          stack.execute_change_set(change_set_name)
+        end
+      end
+
+    end
+
     subcommand "delete", "Delete the change-set." do
 
       def execute

--- a/lib/stackup/change_set.rb
+++ b/lib/stackup/change_set.rb
@@ -1,0 +1,112 @@
+require "stackup/error_handling"
+
+module Stackup
+
+  # An abstraction of a CloudFormation change-set.
+  #
+  class ChangeSet
+
+    def initialize(name, stack)
+      @name = name
+      @stack = stack
+    end
+
+    attr_reader :name
+    attr_reader :stack
+
+    include ErrorHandling
+
+    # Create the change-set.
+    #
+    # Refer +Aws::CloudFormation::Client#create_change_set+
+    #   (see http://docs.aws.amazon.com/sdkforruby/api/Aws/CloudFormation/Client.html#create_change_set-instance_method)
+    #
+    # @param [Hash] options change-set options
+    # @option options [Array<String>] :capabilities (CAPABILITY_NAMED_IAM)
+    #   list of capabilities required for stack template
+    # @option options [String] :description
+    #   change-set description
+    # @option options [String] :notification_arns
+    #   ARNs for the Amazon SNS topics associated with this stack
+    # @option options [Hash, Array<Hash>] :parameters
+    #   stack parameters, either as a Hash, or an Array of
+    #   +Aws::CloudFormation::Types::Parameter+ structures
+    # @option options [Hash, Array<Hash>] :tags
+    #   stack tags, either as a Hash, or an Array of
+    #   +Aws::CloudFormation::Types::Tag+ structures
+    # @option options [Array<String>] :resource_types
+    #   resource types that you have permissions to work with
+    # @option options [Hash] :template
+    #   stack template, as Ruby data
+    # @option options [String] :template_body
+    #   stack template, as JSON or YAML
+    # @option options [String] :template_url
+    #   location of stack template
+    # @option options [boolean] :use_previous_template
+    #   if true, reuse the existing template
+    #
+    # @return [String] change-set id
+    # @raise [Stackup::NoSuchStack] if the stack doesn't exist
+    # @raise [Stackup::StackUpdateError] if operation fails
+    #
+    def create(options = {})
+      options = options.dup
+      options[:stack_name] = stack.name
+      options[:change_set_name] = name
+      options[:change_set_type] = stack.exists? ? "UPDATE" : "CREATE"
+      if (template_data = options.delete(:template))
+        options[:template_body] = MultiJson.dump(template_data)
+      end
+      if (parameters = options[:parameters])
+        options[:parameters] = Parameters.new(parameters).to_a
+      end
+      if (tags = options[:tags])
+        options[:tags] = normalize_tags(tags)
+      end
+      options[:capabilities] ||= ["CAPABILITY_NAMED_IAM"]
+      handling_cf_errors do
+        cf_client.create_change_set(options)
+      end
+    end
+
+    # Execute the change-set.
+    #
+    # @return [String] resulting stack status
+    # @raise [Stackup::NoSuchChangeSet] if the change-set doesn't exist
+    # @raise [Stackup::NoSuchStack] if the stack doesn't exist
+    # @raise [Stackup::StackUpdateError] if operation fails
+    #
+    def execute
+      modify_stack("UPDATE_COMPLETE", "update failed") do
+        cf_client.execute_change_set(:stack_name => stack.name, :change_set_name => name)
+      end
+    end
+
+    # Delete a change-set.
+    #
+    # @raise [Stackup::NoSuchStack] if the stack doesn't exist
+    #
+    def delete
+      handling_cf_errors do
+        cf_client.delete_change_set(:stack_name => stack.name, :change_set_name => name)
+      end
+      nil
+    end
+
+    private
+
+    def cf_client
+      stack.send(:cf_client)
+    end
+
+    def modify_stack(*args, &block)
+      stack.send(:modify_stack, *args, &block)
+    end
+
+    def normalize_tags(tags)
+      stack.send(:normalize_tags, tags)
+    end
+
+  end
+
+end

--- a/lib/stackup/change_set.rb
+++ b/lib/stackup/change_set.rb
@@ -70,7 +70,7 @@ module Stackup
       handling_cf_errors do
         cf_client.create_change_set(options)
         loop do
-          current = describe_change_set
+          current = describe
           logger.debug("change_set_status=#{current.status}")
           case current.status
           when /COMPLETE/
@@ -110,16 +110,23 @@ module Stackup
     end
 
     def status
-      describe_change_set.status
+      describe.status
     end
 
-    private
-
-    def describe_change_set
+    # Describe the change-set.
+    #
+    # Refer +Aws::CloudFormation::Client#describe_change_set+
+    #   (http://docs.aws.amazon.com/sdkforruby/api/Aws/CloudFormation/Client.html#describe_change_set-instance_method)
+    #
+    # @return change-set state, as data
+    #
+    def describe
       handling_cf_errors do
         cf_client.describe_change_set(:stack_name => stack.name, :change_set_name => name)
       end
     end
+
+    private
 
     def cf_client
       stack.send(:cf_client)

--- a/lib/stackup/change_set.rb
+++ b/lib/stackup/change_set.rb
@@ -44,6 +44,8 @@ module Stackup
     #   location of stack template
     # @option options [boolean] :use_previous_template
     #   if true, reuse the existing template
+    # @option options [boolean] :force
+    #   if true, delete any existing change-set of the same name
     #
     # @return [String] change-set id
     # @raise [Stackup::NoSuchStack] if the stack doesn't exist
@@ -54,6 +56,7 @@ module Stackup
       options[:stack_name] = stack.name
       options[:change_set_name] = name
       options[:change_set_type] = stack.exists? ? "UPDATE" : "CREATE"
+      force = options.delete(:force)
       if (template_data = options.delete(:template))
         options[:template_body] = MultiJson.dump(template_data)
       end
@@ -64,6 +67,7 @@ module Stackup
         options[:tags] = normalize_tags(tags)
       end
       options[:capabilities] ||= ["CAPABILITY_NAMED_IAM"]
+      delete if force
       handling_cf_errors do
         cf_client.create_change_set(options)
       end

--- a/lib/stackup/error_handling.rb
+++ b/lib/stackup/error_handling.rb
@@ -6,14 +6,15 @@ module Stackup
   #
   module ErrorHandling
 
-    # Invoke an Aws::CloudFormation operation
+    # Invoke an Aws::CloudFormation operation.
     #
-    # If a +ValidationError+ is raised, check the message; there's often
-    # useful information is hidden inside.  If that's the case, convert it to
-    # an appropriate Stackup exception.
+    # If an exception is raised, convert it to a Stackup exception,
+    # if appropriate.
     #
-    def handling_validation_error
+    def handling_cf_errors
       yield
+    rescue Aws::CloudFormation::Errors::ChangeSetNotFound => e
+      raise NoSuchChangeSet, "no such change-set"
     rescue Aws::CloudFormation::Errors::ValidationError => e
       case e.message
       when /Stack .* does not exist/

--- a/lib/stackup/errors.rb
+++ b/lib/stackup/errors.rb
@@ -6,8 +6,14 @@ module Stackup
   # Raised when something else dodgy happened
   class ValidationError < ServiceError; end
 
+  # Raised when the specified thing does not exist
+  class NoSuchThing < ValidationError; end
+
   # Raised when the specified stack does not exist
-  class NoSuchStack < ValidationError; end
+  class NoSuchStack < NoSuchThing; end
+
+  # Raised when the specified change-set does not exist
+  class NoSuchChangeSet < NoSuchThing; end
 
   # Raised if we can't perform that operation now
   class InvalidStateError < ValidationError; end

--- a/lib/stackup/stack.rb
+++ b/lib/stackup/stack.rb
@@ -49,7 +49,7 @@ module Stackup
     # @raise [Stackup::NoSuchStack] if the stack doesn't exist
     #
     def status
-      handling_validation_error do
+      handling_cf_errors do
         cf_stack.stack_status
       end
     end
@@ -145,7 +145,7 @@ module Stackup
     #
     def delete
       begin
-        @stack_id = handling_validation_error do
+        @stack_id = handling_cf_errors do
           cf_stack.stack_id
         end
       rescue NoSuchStack
@@ -189,7 +189,7 @@ module Stackup
     # @raise [Stackup::NoSuchStack] if the stack doesn't exist
     #
     def template_body
-      handling_validation_error do
+      handling_cf_errors do
         cf_client.get_template(:stack_name => name).template_body
       end
     end
@@ -246,7 +246,7 @@ module Stackup
     # @raise [Stackup::NoSuchStack] if the stack doesn't exist
     #
     def change_set_summaries
-      handling_validation_error do
+      handling_cf_errors do
         cf_client.list_change_sets(:stack_name => name).summaries
       end
     end
@@ -255,6 +255,7 @@ module Stackup
     #
     # @param change_set_name [String] name of change-set to execute
     # @return [String] resulting stack status
+    # @raise [Stackup::NoSuchChangeSet] if the change-set doesn't exist
     # @raise [Stackup::NoSuchStack] if the stack doesn't exist
     # @raise [Stackup::StackUpdateError] if operation fails
     #
@@ -270,7 +271,7 @@ module Stackup
     # @raise [Stackup::NoSuchStack] if the stack doesn't exist
     #
     def delete_change_set(change_set_name)
-      handling_validation_error do
+      handling_cf_errors do
         cf_client.delete_change_set(:stack_name => name, :change_set_name => change_set_name)
       end
       nil
@@ -349,7 +350,7 @@ module Stackup
     #
     def modify_stack_synchronously
       watch do |watcher|
-        handling_validation_error do
+        handling_cf_errors do
           yield
         end
         loop do
@@ -367,7 +368,7 @@ module Stackup
     # @return the stack status
     #
     def modify_stack_asynchronously
-      handling_validation_error do
+      handling_cf_errors do
         yield
       end
       self.status
@@ -391,7 +392,7 @@ module Stackup
     # @return [Hash<String, String>] mapping of collection
     #
     def extract_hash(collection_name, key_name, value_name)
-      handling_validation_error do
+      handling_cf_errors do
         {}.tap do |result|
           cf_stack.public_send(collection_name).each do |item|
             key = item.public_send(key_name)

--- a/lib/stackup/stack.rb
+++ b/lib/stackup/stack.rb
@@ -290,6 +290,7 @@ module Stackup
       options = options.dup
       options[:stack_name] = name
       options[:change_set_name] = change_set_name
+      options[:change_set_type] = "UPDATE"
       if (template_data = options.delete(:template))
         options[:template_body] = MultiJson.dump(template_data)
       end

--- a/lib/stackup/stack.rb
+++ b/lib/stackup/stack.rb
@@ -251,6 +251,60 @@ module Stackup
       end
     end
 
+    # Create a change-set.
+    #
+    # Refer +Aws::CloudFormation::Client#create_change_set+
+    #   (see http://docs.aws.amazon.com/sdkforruby/api/Aws/CloudFormation/Client.html#create_change_set-instance_method)
+    #
+    # @param change_set_name [String] name of change-set
+    # @param [Hash] options change-set options
+    #   accepts a superset of the options supported by
+    # @option options [Array<String>] :capabilities (CAPABILITY_NAMED_IAM)
+    #   list of capabilities required for stack template
+    # @option options [String] :description
+    #   change-set description
+    # @option options [String] :notification_arns
+    #   ARNs for the Amazon SNS topics associated with this stack
+    # @option options [Hash, Array<Hash>] :parameters
+    #   stack parameters, either as a Hash, or an Array of
+    #   +Aws::CloudFormation::Types::Parameter+ structures
+    # @option options [Hash, Array<Hash>] :tags
+    #   stack tags, either as a Hash, or an Array of
+    #   +Aws::CloudFormation::Types::Tag+ structures
+    # @option options [Array<String>] :resource_types
+    #   resource types that you have permissions to work with
+    # @option options [Hash] :template
+    #   stack template, as Ruby data
+    # @option options [String] :template_body
+    #   stack template, as JSON or YAML
+    # @option options [String] :template_url
+    #   location of stack template
+    # @option options [boolean] :use_previous_template
+    #   if true, reuse the existing template
+    #
+    # @return [String] change-set id
+    # @raise [Stackup::NoSuchStack] if the stack doesn't exist
+    # @raise [Stackup::StackUpdateError] if operation fails
+    #
+    def create_change_set(change_set_name, options = {})
+      options = options.dup
+      options[:stack_name] = name
+      options[:change_set_name] = change_set_name
+      if (template_data = options.delete(:template))
+        options[:template_body] = MultiJson.dump(template_data)
+      end
+      if (parameters = options[:parameters])
+        options[:parameters] = Parameters.new(parameters).to_a
+      end
+      if (tags = options[:tags])
+        options[:tags] = normalize_tags(tags)
+      end
+      options[:capabilities] ||= ["CAPABILITY_NAMED_IAM"]
+      handling_cf_errors do
+        cf_client.create_change_set(options)
+      end
+    end
+
     # Execute a change-set.
     #
     # @param change_set_name [String] name of change-set to execute

--- a/lib/stackup/stack.rb
+++ b/lib/stackup/stack.rb
@@ -252,6 +252,13 @@ module Stackup
     end
 
     # Delete a change-set.
+    def execute_change_set(change_set_name)
+      modify_stack("UPDATE_COMPLETE", "update failed") do
+        cf_client.execute_change_set(:stack_name => name, :change_set_name => change_set_name)
+      end
+    end
+
+    # Delete a change-set.
     def delete_change_set(change_set_name)
       handling_validation_error do
         cf_client.delete_change_set(:stack_name => name, :change_set_name => change_set_name)

--- a/lib/stackup/stack.rb
+++ b/lib/stackup/stack.rb
@@ -251,6 +251,14 @@ module Stackup
       end
     end
 
+    # Delete a change-set.
+    def delete_change_set(change_set_name)
+      handling_validation_error do
+        cf_client.delete_change_set(:stack_name => name, :change_set_name => change_set_name)
+      end
+      "DELETED"
+    end
+
     def watch(zero = true)
       watcher = Stackup::StackWatcher.new(cf_stack)
       watcher.zero if zero

--- a/lib/stackup/stack.rb
+++ b/lib/stackup/stack.rb
@@ -273,7 +273,7 @@ module Stackup
       handling_validation_error do
         cf_client.delete_change_set(:stack_name => name, :change_set_name => change_set_name)
       end
-      "DELETED"
+      nil
     end
 
     def watch(zero = true)

--- a/lib/stackup/stack.rb
+++ b/lib/stackup/stack.rb
@@ -240,6 +240,17 @@ module Stackup
       extract_hash(:resource_summaries, :logical_resource_id, :physical_resource_id)
     end
 
+    # List change-sets.
+    #
+    # @return [Array<ChangeSetSummary>]
+    # @raise [Stackup::NoSuchStack] if the stack doesn't exist
+    #
+    def change_set_summaries
+      handling_validation_error do
+        cf_client.list_change_sets(:stack_name => name).summaries
+      end
+    end
+
     def watch(zero = true)
       watcher = Stackup::StackWatcher.new(cf_stack)
       watcher.zero if zero

--- a/lib/stackup/stack.rb
+++ b/lib/stackup/stack.rb
@@ -290,7 +290,7 @@ module Stackup
       options = options.dup
       options[:stack_name] = name
       options[:change_set_name] = change_set_name
-      options[:change_set_type] = "UPDATE"
+      options[:change_set_type] = exists? ? "UPDATE" : "CREATE"
       if (template_data = options.delete(:template))
         options[:template_body] = MultiJson.dump(template_data)
       end

--- a/lib/stackup/stack.rb
+++ b/lib/stackup/stack.rb
@@ -251,7 +251,13 @@ module Stackup
       end
     end
 
-    # Delete a change-set.
+    # Execute a change-set.
+    #
+    # @param change_set_name [String] name of change-set to execute
+    # @return [String] resulting stack status
+    # @raise [Stackup::NoSuchStack] if the stack doesn't exist
+    # @raise [Stackup::StackUpdateError] if operation fails
+    #
     def execute_change_set(change_set_name)
       modify_stack("UPDATE_COMPLETE", "update failed") do
         cf_client.execute_change_set(:stack_name => name, :change_set_name => change_set_name)
@@ -259,6 +265,10 @@ module Stackup
     end
 
     # Delete a change-set.
+    #
+    # @param change_set_name [String] name of change-set to delete
+    # @raise [Stackup::NoSuchStack] if the stack doesn't exist
+    #
     def delete_change_set(change_set_name)
       handling_validation_error do
         cf_client.delete_change_set(:stack_name => name, :change_set_name => change_set_name)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require "byebug"
 require "console_logger"
 
 module CfStubbing

--- a/spec/stackup/stack_spec.rb
+++ b/spec/stackup/stack_spec.rb
@@ -272,6 +272,32 @@ describe Stackup::Stack do
 
     end
 
+    describe "#create_change_set" do
+
+      let(:template) { "stack template" }
+
+      let(:options) do
+        { :template_body => template }
+      end
+
+      def create_change_set
+        stack.create_change_set(change_set_name, options)
+      end
+
+      it "calls :create_change_set" do
+        expected_args = {
+          :stack_name => stack_name,
+          :change_set_name => change_set_name,
+          :change_set_type => "CREATE",
+          :template_body => template
+        }
+        create_change_set
+        expect(cf_client).to have_received(:create_change_set)
+          .with(hash_including(expected_args))
+      end
+
+    end
+
   end
 
   context "with existing stack" do

--- a/spec/stackup/stack_spec.rb
+++ b/spec/stackup/stack_spec.rb
@@ -272,7 +272,7 @@ describe Stackup::Stack do
 
     end
 
-    describe "#create_change_set" do
+    describe "#change_set#create" do
 
       let(:template) { "stack template" }
 
@@ -281,7 +281,7 @@ describe Stackup::Stack do
       end
 
       def create_change_set
-        stack.create_change_set(change_set_name, options)
+        stack.change_set(change_set_name).create(options)
       end
 
       it "calls :create_change_set" do
@@ -531,7 +531,7 @@ describe Stackup::Stack do
 
     end
 
-    describe "#create_change_set" do
+    describe "#change_set#create" do
 
       let(:template) { "stack template" }
 
@@ -540,7 +540,7 @@ describe Stackup::Stack do
       end
 
       def create_change_set
-        stack.create_change_set(change_set_name, options)
+        stack.change_set(change_set_name).create(options)
       end
 
       it "calls :create_change_set" do
@@ -557,7 +557,7 @@ describe Stackup::Stack do
 
     end
 
-    describe "#execute_change_set" do
+    describe "#change_set#execute" do
 
       let(:change_set_name) { "change-it" }
 
@@ -569,7 +569,7 @@ describe Stackup::Stack do
       end
 
       def execute_change_set
-        stack.execute_change_set(change_set_name)
+        stack.change_set(change_set_name).execute
       end
 
       it "calls :execute_change_set" do
@@ -608,12 +608,12 @@ describe Stackup::Stack do
 
     end
 
-    describe "#delete_change_set" do
+    describe "#change_set#delete" do
 
       let(:change_set_name) { "change-it" }
 
       it "calls :delete_change_set" do
-        stack.delete_change_set(change_set_name)
+        stack.change_set(change_set_name).delete
         expected_args = {
           :stack_name => stack_name,
           :change_set_name => change_set_name

--- a/spec/stackup/stack_spec.rb
+++ b/spec/stackup/stack_spec.rb
@@ -296,6 +296,60 @@ describe Stackup::Stack do
           .with(hash_including(expected_args))
       end
 
+      context "with :template as data" do
+
+        let(:options) do
+          { :template => { "foo" => "bar" } }
+        end
+
+        it "converts the template to JSON" do
+          create_change_set
+          expect(cf_client).to have_received(:create_change_set)
+            .with(hash_including(:template_body))
+        end
+
+      end
+
+      context "with :parameters as Hash" do
+
+        before do
+          options[:parameters] = { "foo" => "bar" }
+        end
+
+        it "converts them to an Array" do
+          expected_parameters = [
+            {
+              :parameter_key => "foo",
+              :parameter_value => "bar"
+            }
+          ]
+          create_change_set
+          expect(cf_client).to have_received(:create_change_set) do |options|
+            expect(options[:parameters]).to eq(expected_parameters)
+          end
+        end
+
+      end
+
+      context "with :tags as Hash" do
+
+        before do
+          options[:tags] = { "foo" => "bar", "code" => 123 }
+        end
+
+        it "converts them to an Array" do
+          expected_tags = [
+            { :key => "foo", :value => "bar" },
+            { :key => "code", :value => "123" }
+          ]
+          create_change_set
+          expect(cf_client).to have_received(:create_change_set) do |options|
+            expect(options[:tags]).to eq(expected_tags)
+          end
+        end
+
+      end
+
     end
 
   end

--- a/spec/stackup/stack_spec.rb
+++ b/spec/stackup/stack_spec.rb
@@ -10,6 +10,8 @@ describe Stackup::Stack do
   let(:unique_stack_id) { "ID:#{stack_name}" }
   let(:stack_options) { {} }
 
+  let(:change_set_name) { "ch-ch-changes" }
+
   subject(:stack) { described_class.new(stack_name, cf_client, stack_options) }
 
   before do
@@ -21,6 +23,7 @@ describe Stackup::Stack do
     allow(cf_client).to receive(:update_stack).and_call_original
     allow(cf_client).to receive(:cancel_update_stack).and_call_original
     allow(cf_client).to receive(:list_change_sets).and_call_original
+    allow(cf_client).to receive(:create_change_set).and_call_original
     allow(cf_client).to receive(:execute_change_set).and_call_original
     allow(cf_client).to receive(:delete_change_set).and_call_original
   end
@@ -444,6 +447,32 @@ describe Stackup::Stack do
         expect(summaries.map(&:change_set_name)).to eql(%w(take1 take2))
         expect(cf_client).to have_received(:list_change_sets)
           .with(:stack_name => stack_name)
+      end
+
+    end
+
+    describe "#create_change_set" do
+
+      let(:template) { "stack template" }
+
+      let(:options) do
+        { :template_body => template }
+      end
+
+      def create_change_set
+        stack.create_change_set(change_set_name, options)
+      end
+
+      it "calls :create_change_set" do
+        expected_args = {
+          :stack_name => stack_name,
+          :change_set_name => change_set_name,
+          :change_set_type => "UPDATE",
+          :template_body => template
+        }
+        create_change_set
+        expect(cf_client).to have_received(:create_change_set)
+          .with(hash_including(expected_args))
       end
 
     end

--- a/spec/stackup/stack_spec.rb
+++ b/spec/stackup/stack_spec.rb
@@ -16,6 +16,7 @@ describe Stackup::Stack do
 
   before do
     cf_client.stub_responses(:describe_stacks, *describe_stacks_responses)
+    cf_client.stub_responses(:describe_change_set, *describe_change_set_responses)
     allow(stack).to receive(:sleep).at_most(5).times
     # partial stubbing, to support spying
     allow(cf_client).to receive(:create_stack).and_call_original
@@ -26,6 +27,7 @@ describe Stackup::Stack do
     allow(cf_client).to receive(:create_change_set).and_call_original
     allow(cf_client).to receive(:execute_change_set).and_call_original
     allow(cf_client).to receive(:delete_change_set).and_call_original
+    allow(cf_client).to receive(:describe_change_set).and_call_original
   end
 
   def error(type, message)
@@ -55,6 +57,14 @@ describe Stackup::Stack do
         }.merge(details)
       ]
     }
+  end
+
+  let(:describe_change_set_responses) do
+    [
+      {
+        :status => "CREATE_COMPLETE"
+      }
+    ]
   end
 
   context "before stack exists" do


### PR DESCRIPTION
An attempt at implementing #24.

```
$ stackup stack-name 
Usage:
    stackup [OPTIONS] NAME SUBCOMMAND [ARG] ...

Subcommands:
    ...
    change-sets                   List change-sets.
    change-set                    Change-set operations.

$ stackup stack-name change-set
Usage:
    stackup NAME change-set [OPTIONS] SUBCOMMAND [ARG] ...

Subcommands:
    create                        Create a change-set.
    changes                       Describe the change-set.
    inspect                       Show full change-set details.
    apply, execute                Apply the change-set.
    delete                        Delete the change-set.
```

Feedback (and testing) invited.
