### PR TITLE
Limit GetAtt split to two args

### DIFF
--- a/lib/stackup/yaml.rb
+++ b/lib/stackup/yaml.rb
@@ -64,7 +64,7 @@ module Stackup
 
       def array_or_dotted_string(arg)
         if arg.respond_to?(:split)
-          arg.split(".")
+          arg.split(".", 2)
         else
           arg
         end

--- a/spec/stackup/yaml_spec.rb
+++ b/spec/stackup/yaml_spec.rb
@@ -100,6 +100,30 @@ describe Stackup::YAML do
 
       end
 
+      context "with a string with multiple dots" do
+
+        let(:input) do
+          <<-YAML
+          Outputs:
+            Foo: !GetAtt Bar.Baz.Some.More.Things
+          YAML
+        end
+
+        it "splits on the first dot" do
+          expect(data).to eql(
+            "Outputs" => {
+              "Foo" => {
+                "Fn::GetAtt" => [
+                  "Bar",
+                  "Baz.Some.More.Things"
+                ]
+              }
+            }
+          )
+        end
+
+      end
+
     end
 
     describe "!GetAZs" do


### PR DESCRIPTION
There can be dots in the second argument of `Fn::GetAtt`, such as:
```
{ "Fn::GetAtt": ["Database", "Endpoint.Address"] }
```

When using the short `yaml` form `!GetAtt`, the split should produce only two args.