### PR TITLE
Support empty files in --parameters list.

### DIFF
--- a/lib/stackup/parameters.rb
+++ b/lib/stackup/parameters.rb
@@ -7,6 +7,7 @@ module Stackup
     class << self
 
       def new(arg)
+        arg ||= {}
         arg = hashify(arg) unless arg.is_a?(Hash)
         super(arg)
       end

--- a/spec/stackup/parameters_spec.rb
+++ b/spec/stackup/parameters_spec.rb
@@ -143,6 +143,22 @@ describe Stackup::Parameters do
       end
 
     end
+    context "with empty parameter file" do
+
+      let(:input_records) { false }
+
+      subject(:parameters) { Stackup::Parameters.new(input_records) }
+
+      describe "#to_hash" do
+
+        it "doesn't crash" do
+          expected = {}
+          expect(parameters.to_hash).to eql(expected)
+        end
+
+      end
+
+    end
 
   end
 

--- a/spec/stackup/parameters_spec.rb
+++ b/spec/stackup/parameters_spec.rb
@@ -143,6 +143,7 @@ describe Stackup::Parameters do
       end
 
     end
+    
     context "with empty parameter file" do
 
       let(:input_records) { false }


### PR DESCRIPTION
When using `stackup` in a Makefile which has automatically generated
targets, i would like to be able to deploy a stack which requires no
parameters using the same command invocation as a stack which does
require parameters.  To achieve this, i sometimes want to pass an
empty file in to the `--parameters` option of stackup.

This patch initialises the input to an empty hash if it doesn't have a
value (as is the case when reading an empty file) and adds a spec
around that behaviour.

* lib/stackup/parameters.rb (new): Initialise the `arg` variable if it
  is false (this would otherwise cause `#hashify` to crash).
* spec/stackup/parameters_spec.rb: Add a spec to check behaviour of
  `Parameters#new` when given `false`.

Co-author: @jonhiggs