### PR TITLE
Update README.md to cover override with parameter file

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,12 @@ You may specify `-p` multiple times; `stackup` will read and merge all the files
       -p defaults.json \
       -p overrides.json
 
-Or, you can specify parameters on the command-line, via `-o`:
+Or, you may also specify one or more override parameter on the command-line, via `-o` along with `-p`:
 
     $ stackup myapp-test up -t template.json \
-      -o IndexDoc=index.html
+      -p defaults.json \
+      -o IndexDoc=index-override.html
+      -o ContentDoc=content-override.html
 
 ### YAML support
 


### PR DESCRIPTION
Clarify `-o` can be used in conjunction with `-p` and can have more than one.