### PR TITLE
Use the aws-sdk-cloudformation gem instead of aws-sdk-resources.

### DIFF
--- a/lib/stackup/service.rb
+++ b/lib/stackup/service.rb
@@ -1,4 +1,4 @@
-require "aws-sdk-core"
+require "aws-sdk-cloudformation"
 require "stackup/stack"
 
 module Stackup

--- a/lib/stackup/source.rb
+++ b/lib/stackup/source.rb
@@ -1,4 +1,3 @@
-require "aws-sdk-core"
 require "open-uri"
 require "stackup/stack"
 

--- a/lib/stackup/stack.rb
+++ b/lib/stackup/stack.rb
@@ -1,4 +1,4 @@
-require "aws-sdk-resources"
+require "aws-sdk-cloudformation"
 require "logger"
 require "multi_json"
 require "stackup/change_set"

--- a/lib/stackup/stack_watcher.rb
+++ b/lib/stackup/stack_watcher.rb
@@ -1,4 +1,4 @@
-require "aws-sdk-core"
+require "aws-sdk-cloudformation"
 
 module Stackup
 

--- a/spec/stackup/stack_watcher_spec.rb
+++ b/spec/stackup/stack_watcher_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-require "aws-sdk-resources"
+require "aws-sdk-cloudformation"
 require "securerandom"
 require "stackup/stack_watcher"
 

--- a/stackup.gemspec
+++ b/stackup.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables << "stackup"
 
   spec.add_dependency "aws-sdk-core", "~> 3.0"
-  spec.add_dependency "aws-sdk-resources", "~> 3.0"
+  spec.add_dependency "aws-sdk-cloudformation", "~> 1.6"
   spec.add_dependency "clamp", "~> 1.2"
   spec.add_dependency "console_logger"
   spec.add_dependency "diffy", "~> 3.2"

--- a/stackup.gemspec
+++ b/stackup.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.bindir = "bin"
   spec.executables << "stackup"
 
-  spec.add_dependency "aws-sdk-core", "~> 3.0"
   spec.add_dependency "aws-sdk-cloudformation", "~> 1.6"
   spec.add_dependency "clamp", "~> 1.2"
   spec.add_dependency "console_logger"


### PR DESCRIPTION
Fixes #60.