### PR TITLE
Make CloudFormation diff context size configurable.

### DIFF
--- a/bin/stackup
+++ b/bin/stackup
@@ -347,6 +347,8 @@ Clamp do
 
     option "--diff-format", "FORMAT", "'text', 'color', or 'html'", :default => "color"
 
+    option "--context-lines", "LINES", "number of lines of context to show", :default => 10_000
+
     option ["-t", "--template"], "FILE", "template source",
            :attribute_name => :template_source,
            &Stackup::Source.method(:new)
@@ -373,7 +375,7 @@ Clamp do
         planned["Tags"] = tag_source.data.sort.to_h
       end
       signal_usage_error "specify '--template' or '--parameters'" if planned.empty?
-      puts differ.diff(current, planned)
+      puts differ.diff(current, planned, context_lines)
     end
 
     private

--- a/lib/stackup/differ.rb
+++ b/lib/stackup/differ.rb
@@ -17,10 +17,10 @@ module Stackup
 
     include Utils
 
-    def diff(existing_data, pending_data)
+    def diff(existing_data, pending_data, context_lines)
       existing = format(normalize_data(existing_data)) + "\n"
       pending = format(normalize_data(pending_data)) + "\n"
-      diff = Diffy::Diff.new(existing, pending).to_s(diff_style)
+      diff = Diffy::Diff.new(existing, pending, context: context_lines).to_s(diff_style)
       diff unless diff =~ /\A\s*\Z/
     end
 


### PR DESCRIPTION
As a user, i sometimes want to be able to see *less* context around my CloudFormation diffs than the entire file as is currently the case, because for small changes, the full file can be an overwhelming screen-full.

This patch doesn't change the default behaviour of Stackup, it keeps the default of 10,000 lines of context as defined in the Diffy library (see https://github.com/samg/diffy#number-of-lines-of-context-around-changes).