### PR TITLE
Don't set diffy context lines by default.

### DIFF
--- a/lib/stackup/differ.rb
+++ b/lib/stackup/differ.rb
@@ -17,7 +17,7 @@ module Stackup
 
     include Utils
 
-    def diff(existing_data, pending_data, context_lines)
+    def diff(existing_data, pending_data, context_lines = nil)
       existing = format(normalize_data(existing_data)) + "\n"
       pending = format(normalize_data(pending_data)) + "\n"
       diff = Diffy::Diff.new(existing, pending, context: context_lines).to_s(diff_style)


### PR DESCRIPTION
Well..set the context lines to nil by default.

In one of our projects, we use stackup as a library.

https://github.com/realestate-com-au/stackup/commit/a8648b3b74082e0dbe665b6ab4a05e7e11d5ba57#diff-e13472b08a3fb472307df53981205a0bL20 introduced a breaking change by adding a new mandatory argument to the `diff` method.

It looks like diffy uses context = nil by default. https://github.com/samg/diffy/blob/master/lib/diffy/diff.rb#L8