### PR TITLE
Safe handling of the options parameter in create and update stack

### DIFF
--- a/lib/stackup/stack.rb
+++ b/lib/stackup/stack.rb
@@ -281,6 +281,7 @@ module Stackup
     end
 
     def create(options)
+      options = options.dup
       options[:stack_name] = name
       options.delete(:stack_policy_during_update_body)
       options.delete(:stack_policy_during_update_url)
@@ -290,6 +291,7 @@ module Stackup
     end
 
     def update(options)
+      options = options.dup
       options.delete(:disable_rollback)
       options.delete(:on_failure)
       options.delete(:timeout_in_minutes)

--- a/spec/stackup/stack_spec.rb
+++ b/spec/stackup/stack_spec.rb
@@ -644,7 +644,7 @@ describe Stackup::Stack do
           let(:template) { "stack template" }
 
           def create_or_update
-            stack.create_or_update(:template_body => template)
+            stack.create_or_update(:template_body => template, :disable_rollback => true)
           end
 
           let(:describe_stacks_responses) do
@@ -667,6 +667,14 @@ describe Stackup::Stack do
             create_or_update
             expect(cf_client).to have_received(:delete_stack)
             expect(cf_client).to have_received(:create_stack)
+
+            expected_args = {
+              :stack_name => stack_name,
+              :template_body => template,
+              :disable_rollback => true
+            }
+            expect(cf_client).to have_received(:create_stack)
+              .with(hash_including(expected_args))
           end
 
         end


### PR DESCRIPTION
As per issue https://github.com/realestate-com-au/stackup/issues/64, the create and update stack functions are mutating the options parameter passed to it.

When a stack with bad cloudformation has been created with disable_rollback=true, it completes with an expected state of CREATE_FAILED with no rollback of resources. If you run the same create stack action via stackup, you'd expect it to complete with CREATE_FAILED and no rollbacks.

However, through a sequence of events and function calls, the disable_rollback option has been removed from the original options parameter, thereby causing the second create stack action to fail and rollback.

Tests after code changes:
* Ran create stack +disable_rollback=true using the same stack name multiple times, and ensured that a bad cloudformation template causes a CREATE_FAILED with no rollback of resources every time
* Updated the spec tests to validate the scenario above