### PR TITLE
Don't fail when creating a stack with change sets

### DIFF
--- a/lib/stackup/change_set.rb
+++ b/lib/stackup/change_set.rb
@@ -87,7 +87,7 @@ module Stackup
     # @raise [Stackup::StackUpdateError] if operation fails
     #
     def execute
-      modify_stack("UPDATE_COMPLETE", "update failed") do
+      modify_stack(/(CREATE|UPDATE)_COMPLETE/, "update failed") do
         cf_client.execute_change_set(:stack_name => stack.name, :change_set_name => name)
       end
     end

--- a/spec/stackup/stack_spec.rb
+++ b/spec/stackup/stack_spec.rb
@@ -362,6 +362,37 @@ describe Stackup::Stack do
 
     end
 
+    describe "#change_set#execute" do
+
+      let(:change_set_name) { "create-it" }
+
+      let(:describe_stacks_responses) do
+        [
+          stack_description("CREATE_IN_PROGRESS"),
+          stack_description("CREATE_COMPLETE")
+        ]
+      end
+
+      def execute_change_set
+        stack.change_set(change_set_name).execute
+      end
+
+      it "calls :execute_change_set" do
+        execute_change_set
+        expected_args = {
+          :stack_name => stack_name,
+          :change_set_name => change_set_name
+        }
+        expect(cf_client).to have_received(:execute_change_set)
+          .with(hash_including(expected_args))
+      end
+
+      it "returns status" do
+        expect(execute_change_set).to eq("CREATE_COMPLETE")
+      end
+
+    end
+
   end
 
   context "with existing stack" do


### PR DESCRIPTION
- Update change set execute to permit CREATE_COMPLETE
- Add spec for case where execute is called on new change set

When creating a new stack with change-set execute stackup created the stack then failed with the following error:

`
2019-07-30T06:37:55.707481591Z ERROR: update failed
`

This is because the expected state didn't match the state of the stack (CREATE_COMPLETE).