### PR TITLE
Add CAPABILITY_AUTO_EXPAND by default

### DIFF
--- a/lib/stackup/change_set.rb
+++ b/lib/stackup/change_set.rb
@@ -59,7 +59,7 @@ module Stackup
       options[:template_body] = MultiJson.dump(options.delete(:template)) if options[:template]
       options[:parameters] = Parameters.new(options[:parameters]).to_a if options[:parameters]
       options[:tags] = normalize_tags(options[:tags]) if options[:tags]
-      options[:capabilities] ||= ["CAPABILITY_NAMED_IAM"]
+      options[:capabilities] ||= ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
       delete if force
       handling_cf_errors do
         cf_client.create_change_set(options)

--- a/lib/stackup/stack.rb
+++ b/lib/stackup/stack.rb
@@ -129,7 +129,7 @@ module Stackup
       if (policy_data = options.delete(:stack_policy_during_update))
         options[:stack_policy_during_update_body] = MultiJson.dump(policy_data)
       end
-      options[:capabilities] ||= ["CAPABILITY_NAMED_IAM"]
+      options[:capabilities] ||= ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
       delete if ALMOST_DEAD_STATUSES.include?(status)
       update(options)
     rescue NoSuchStack


### PR DESCRIPTION
CAPABILITY_AUTO_EXPAND enables deployment of stacks containing macros, including nested stacks defined using the AWS::Serverless::Application resource type.