### PR TITLE
Add support for CloudFormation capabilities

### DIFF
--- a/bin/stackup
+++ b/bin/stackup
@@ -201,6 +201,9 @@ Clamp do
            "when stack creation fails: DO_NOTHING, ROLLBACK, or DELETE",
            :default => "ROLLBACK"
 
+    option "--capability", "CAPABILITY", "cloudformation capability",
+           :multivalued => true, :default => ["CAPABILITY_NAMED_IAM"]
+
     def execute
       unless template_source || use_previous_template?
         signal_usage_error "Specify either --template or --use-previous-template"
@@ -225,6 +228,7 @@ Clamp do
       end
       options[:role_arn] = service_role_arn if service_role_arn
       options[:use_previous_template] = use_previous_template?
+      options[:capabilities] = capability_list
       report_change do
         stack.create_or_update(options)
       end
@@ -279,6 +283,9 @@ Clamp do
              :attribute_name => :tag_source,
              &Stackup::Source.method(:new)
 
+      option "--capability", "CAPABILITY", "cloudformation capability",
+             :multivalued => true, :default => ["CAPABILITY_NAMED_IAM"]
+
       def execute
         unless template_source || use_previous_template?
           signal_usage_error "Specify either --template or --use-previous-template"
@@ -296,6 +303,7 @@ Clamp do
         options[:tags] = tag_source.data if tag_source
         options[:use_previous_template] = use_previous_template?
         options[:force] = force?
+        options[:capabilities] = capability_list
         report_change do
           change_set.create(options)
         end

--- a/examples/Rakefile
+++ b/examples/Rakefile
@@ -5,7 +5,11 @@ Stackup::RakeTasks.new("demo") do |t|
   t.template = "template.json"
   t.parameters = "parameters-verbose.json"
   t.tags = {
-    "environment" => "dev",
-    "team" => "rea-oss"
+      "environment" => "dev",
+      "team" => "rea-oss"
   }
+  t.capabilities = [
+      "CAPABILITY_IAM",
+      "CAPABILITY_NAMED_IAM"
+  ]
 end

--- a/lib/stackup/rake_tasks.rb
+++ b/lib/stackup/rake_tasks.rb
@@ -83,7 +83,7 @@ module Stackup
 
       def initialize(flag, argument)
         @flag = flag
-        @argument = argument if argument
+        @argument = argument
       end
 
       def to_a
@@ -111,14 +111,14 @@ module Stackup
     class DataOptionHash < DataOption
 
       def as_tempfile(filename, data)
-        tempfile = Tempfile.new(filename)
+        tempfile = Tempfile.new([filename, ".yml"])
         tempfile.write(YAML.dump(data))
         tempfile.close
         tempfile.path.to_s
       end
 
       def to_a
-        [@flag, as_tempfile([@flag[2..-1], ".yml"], @argument)]
+        [@flag, as_tempfile(@flag[2..-1], @argument)]
       end
 
     end
@@ -128,12 +128,7 @@ module Stackup
     class DataOptionArray < DataOption
 
       def to_a
-        [].tap do |result|
-          @argument.each do |argument|
-            result << @flag
-            result << argument
-          end
-        end
+        @argument.map { |a| [@flag, a] }.flatten
       end
 
     end

--- a/spec/stackup/stack_spec.rb
+++ b/spec/stackup/stack_spec.rb
@@ -280,6 +280,22 @@ describe Stackup::Stack do
 
       end
 
+      context "with :capabilities as an Array" do
+
+        before do
+          options[:capabilities] = %w[CAPABILITY_IAM CAPABILITY_NAMED_IAM]
+        end
+
+        it "passes them through" do
+          expected_capabilities = %w[CAPABILITY_IAM CAPABILITY_NAMED_IAM]
+          create_or_update
+          expect(cf_client).to have_received(:create_stack) do |options|
+            expect(options[:capabilities]).to eq(expected_capabilities)
+          end
+        end
+
+      end
+
     end
 
     describe "#change_set#create" do
@@ -355,6 +371,22 @@ describe Stackup::Stack do
           create_change_set
           expect(cf_client).to have_received(:create_change_set) do |options|
             expect(options[:tags]).to eq(expected_tags)
+          end
+        end
+
+      end
+
+      context "with :capabilities as an Array" do
+
+        before do
+          options[:capabilities] = %w[CAPABILITY_IAM CAPABILITY_NAMED_IAM]
+        end
+
+        it "passes them through" do
+          expected_capabilities = %w[CAPABILITY_IAM CAPABILITY_NAMED_IAM]
+          create_change_set
+          expect(cf_client).to have_received(:create_change_set) do |options|
+            expect(options[:capabilities]).to eq(expected_capabilities)
           end
         end
 


### PR DESCRIPTION
Allows users to pass capabilities as arguments to stackup via both command-line and Rake.

Hopefully addresses the concerns raised in https://github.com/realestate-com-au/stackup/pull/73.