### PR TITLE
Fix for accepting tags in AWS style from a file

### DIFF
--- a/lib/stackup/stack.rb
+++ b/lib/stackup/stack.rb
@@ -364,13 +364,21 @@ module Stackup
     end
 
     def normalize_tags(tags)
+      tag_array = []
       if tags.is_a?(Hash)
         tags.map do |key, value|
-          { :key => key, :value => value.to_s }
+          tag_array += [{ :key => key, :value => value.to_s }]
         end
       else
-        tags
+        for tag in tags do
+          if tag.key?('Key')
+            tag_array += [{ :key => tag['Key'], :value => tag['Value'].to_s }]
+          else
+            tag_array += [{ :key => tag[:key], :value => tag[:value].to_s }]
+          end
+        end
       end
+      return tag_array
     end
 
     # Extract data from a collection attribute of the stack.

--- a/spec/stackup/stack_spec.rb
+++ b/spec/stackup/stack_spec.rb
@@ -260,6 +260,26 @@ describe Stackup::Stack do
 
       end
 
+      context "with :tags in SDK form as they arrive from file" do
+
+        before do
+          options[:tags] = [
+            { "Key" => "foo", "Value" => "bar" }
+          ]
+        end
+
+        it "converts them to an Array, that uses symbols as keys" do
+          expected_tags = [
+            { :key => "foo", :value => "bar" },
+          ]
+          create_or_update
+          expect(cf_client).to have_received(:create_stack) do |options|
+            expect(options[:tags]).to eq(expected_tags)
+          end
+        end
+
+      end
+
       context "with :tags in SDK form" do
 
         before do


### PR DESCRIPTION
This PR fixes Stackup so that it doesn't error out when receiving tags in AWS style (array of hashes) from YAML or JSON file.

Please excuse my "brute force" approach.  I did consider using something like `require 'active_support/hash_with_indifferent_access'` ... but I didn't want to mess with the dependencies of the project.