### PR TITLE
Add a test stage before the runtime Docker image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 .git
 *.gem
-Gemfile*
 pkg/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,19 @@
+#--- Multistage Dockerfile: must pass tests first
+FROM ruby:2.6 as test
+
+MAINTAINER https://github.com/realestate-com-au/stackup
+
+RUN apt-get update \
+ && apt-get install -y \
+        diffutils
+
+ADD . /app
+WORKDIR /app
+
+RUN bundle install
+RUN bundle exec rake
+
+#--- Multistage Dockerfile: run-time container
 FROM ruby:2.6-alpine@sha256:65c14862929f88ba54cebd63177d9437c46dda2e7c47484fb1d3178825dd1585
 
 MAINTAINER https://github.com/realestate-com-au/stackup


### PR DESCRIPTION
I'm a very occasional Ruby developer, and I don't have Ruby, rake, etc. installed on my laptop.
This allows me to do local testing.

It might be useful also to "enforce" passing tests before building the runtime image?