### PR TITLE
Add optional non-normalisation of templates on upload to Cloudformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,9 @@ This is to provide backwards compatibility with previously deployed stacks and m
 
 It also supports the [abbreviated YAML syntax for Cloudformation functions](https://aws.amazon.com/blogs/aws/aws-cloudformation-update-yaml-cross-stack-references-simplified-substitution/), though unlike the [AWS CLI](https://aws.amazon.com/cli/), Stackup (by default) normalises YAML input to JSON before invoking CloudFormation APIs.
 
-If you don't want normalisation of the YAML input, then use the `--preserve-template-formatting` flag to the `up` or `change-set create` commands.
+If you don't want normalisation of the YAML input to JSON, then use the `--preserve-template-formatting` flag to the `up` or `change-set create` commands.
 
-**TODO: test what happens with s3 stored templates**
+Note: normalisation of S3 / HTTP URL stored templates is never done, as Cloudformation collects these directly.
 
 ### AWS credentials
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,11 @@ This is to provide backwards compatibility with previously deployed stacks and m
 
 `stackup` supports input files (template, parameters, tags) in YAML format, as well as JSON.
 
-It also supports the [abbreviated YAML syntax for Cloudformation functions](https://aws.amazon.com/blogs/aws/aws-cloudformation-update-yaml-cross-stack-references-simplified-substitution/), though unlike the [AWS CLI](https://aws.amazon.com/cli/), Stackup normalises YAML input to JSON before invoking CloudFormation APIs.
+It also supports the [abbreviated YAML syntax for Cloudformation functions](https://aws.amazon.com/blogs/aws/aws-cloudformation-update-yaml-cross-stack-references-simplified-substitution/), though unlike the [AWS CLI](https://aws.amazon.com/cli/), Stackup (by default) normalises YAML input to JSON before invoking CloudFormation APIs.
+
+If you don't want normalisation of the YAML input, then use the `--preserve-template-formatting` flag to the `up` or `change-set create` commands.
+
+**TODO: test what happens with s3 stored templates**
 
 ### AWS credentials
 

--- a/bin/stackup
+++ b/bin/stackup
@@ -214,6 +214,7 @@ Clamp do
           options[:template_url] = template_source.location
         else
           options[:template] = template_source.data
+          options[:template_orig] = template_source.body
         end
       end
       options[:on_failure] = on_failure

--- a/bin/stackup
+++ b/bin/stackup
@@ -181,6 +181,9 @@ Clamp do
     option ["-T", "--use-previous-template"], :flag,
            "reuse the existing template"
 
+    option ["-P", "--preserve-template-formatting"], :flag,
+           "do not normalise the template when calling the Cloudformation APIs; useful for preserving YAML and comments"
+
     include HasParameters
 
     option "--tags", "FILE", "stack tags file",
@@ -230,6 +233,7 @@ Clamp do
       options[:role_arn] = service_role_arn if service_role_arn
       options[:use_previous_template] = use_previous_template?
       options[:capabilities] = capability_list
+      options[:preserve] = preserve_template_formatting?
       report_change do
         stack.create_or_update(options)
       end
@@ -275,6 +279,9 @@ Clamp do
       option ["-T", "--use-previous-template"], :flag,
              "reuse the existing template"
 
+      option ["-P", "--preserve-template-formatting"], :flag,
+             "do not normalise the template when calling the Cloudformation APIs; useful for preserving YAML and comments"
+
       option ["--force"], :flag,
              "replace existing change-set of the same name"
 
@@ -297,6 +304,7 @@ Clamp do
             options[:template_url] = template_source.location
           else
             options[:template] = template_source.data
+            options[:template_orig] = template_source.body
           end
         end
         options[:parameters] = parameters
@@ -305,6 +313,7 @@ Clamp do
         options[:use_previous_template] = use_previous_template?
         options[:force] = force?
         options[:capabilities] = capability_list
+        options[:preserve] = preserve_template_formatting?
         report_change do
           change_set.create(options)
         end

--- a/bin/stackup
+++ b/bin/stackup
@@ -375,6 +375,9 @@ Clamp do
            :attribute_name => :template_source,
            &Stackup::Source.method(:new)
 
+    option ["-P", "--preserve-template-formatting"], :flag,
+           "do not normalise the templates when performing the diff"
+
     include HasParameters
 
     option "--tags", "FILE", "stack tags file",
@@ -387,6 +390,10 @@ Clamp do
       if template_source
         current["Template"] = stack.template
         planned["Template"] = template_source.data
+        if preserve_template_formatting?
+          current["Template"] = stack.template_body
+          planned["Template"] = template_source.body
+        end
       end
       unless parameter_sources.empty?
         current["Parameters"] = existing_parameters.sort.to_h

--- a/bin/stackup
+++ b/bin/stackup
@@ -375,9 +375,6 @@ Clamp do
            :attribute_name => :template_source,
            &Stackup::Source.method(:new)
 
-    option ["-P", "--preserve-template-formatting"], :flag,
-           "do not normalise the templates when performing the diff"
-
     include HasParameters
 
     option "--tags", "FILE", "stack tags file",
@@ -390,10 +387,6 @@ Clamp do
       if template_source
         current["Template"] = stack.template
         planned["Template"] = template_source.data
-        if preserve_template_formatting?
-          current["Template"] = stack.template_body
-          planned["Template"] = template_source.body
-        end
       end
       unless parameter_sources.empty?
         current["Parameters"] = existing_parameters.sort.to_h

--- a/lib/stackup/change_set.rb
+++ b/lib/stackup/change_set.rb
@@ -57,6 +57,11 @@ module Stackup
       options[:change_set_type] = stack.exists? ? "UPDATE" : "CREATE"
       force = options.delete(:force)
       options[:template_body] = MultiJson.dump(options.delete(:template)) if options[:template]
+      # optionally override template_body with the original template to preserve formatting (& comments in YAML)
+      template_orig = options.delete(:template_orig)
+      if (options.delete(:preserve))
+        options[:template_body] = template_orig
+      end
       options[:parameters] = Parameters.new(options[:parameters]).to_a if options[:parameters]
       options[:tags] = normalize_tags(options[:tags]) if options[:tags]
       options[:capabilities] ||= ["CAPABILITY_NAMED_IAM"]

--- a/lib/stackup/stack.rb
+++ b/lib/stackup/stack.rb
@@ -119,6 +119,10 @@ module Stackup
       if (template_data = options.delete(:template))
         options[:template_body] = MultiJson.dump(template_data)
       end
+      # override template_body with the original template to preserve formatting (& comments in YAML)
+      if (template_orig = options.delete(:template_orig))
+        options[:template_body] = template_orig
+      end
       if (parameters = options[:parameters])
         options[:parameters] = Parameters.new(parameters).to_a
       end

--- a/lib/stackup/stack.rb
+++ b/lib/stackup/stack.rb
@@ -119,8 +119,9 @@ module Stackup
       if (template_data = options.delete(:template))
         options[:template_body] = MultiJson.dump(template_data)
       end
-      # override template_body with the original template to preserve formatting (& comments in YAML)
-      if (template_orig = options.delete(:template_orig))
+      # optionally override template_body with the original template to preserve formatting (& comments in YAML)
+      template_orig = options.delete(:template_orig)
+      if (options.delete(:preserve))
         options[:template_body] = template_orig
       end
       if (parameters = options[:parameters])


### PR DESCRIPTION
As per the [README](https://github.com/realestate-com-au/stackup/blob/v1.4.5/README.md#yaml-support), and discussions in #31, #74 & #81 - Stackup normalises YAML input to JSON before invoking Cloudformation API's.

This functionality exists because Stackup supported YAML before Cloudformation did.

This PR adds an optional flag (`--preserve-template-formatting`) to the `up` and `change-set create` commands upload templates in their original format (do not normalise).

Why?  Because the YAML formatting is easier to read & can include comments.
It's good to be able to preserve this format for viewing in the AWS web-console.