### PR TITLE
Allow a new variety of s3 url

### DIFF
--- a/lib/stackup/source.rb
+++ b/lib/stackup/source.rb
@@ -15,7 +15,7 @@ module Stackup
 
     def s3?
       uri.scheme == "https" &&
-        uri.host =~ /(^|\.)s3(-\w+-\w+-\d)?\.amazonaws\.com$/
+        uri.host =~ /(^|\.)s3((\.|-)\w+-\w+-\d)?\.amazonaws\.com$/
     end
 
     def body

--- a/spec/stackup/source_spec.rb
+++ b/spec/stackup/source_spec.rb
@@ -124,6 +124,16 @@ describe Stackup::Source do
 
     end
 
+    context "with dot separated bucket and region" do
+
+      let(:s3_url) { "https://bucket.s3.us-east-1.amazonaws.com/cfn/template.yml" }
+
+      it "is S3" do
+        expect(subject).to be_s3
+      end
+
+    end
+
   end
 
 end


### PR DESCRIPTION
I noticed this one in the wild today.  Because it's not recognised stackup fails due to template body size restrictions.