### PR TITLE
Convert param input to String

### DIFF
--- a/lib/stackup/parameters.rb
+++ b/lib/stackup/parameters.rb
@@ -45,7 +45,7 @@ module Stackup
           if value == :use_previous_value
             record[:use_previous_value] = true
           else
-            record[:parameter_value] = value.to_s
+            record[:parameter_value] = ParameterValue.new(value).to_param
           end
         end
       end
@@ -75,7 +75,26 @@ module Stackup
       if use_previous_value
         :use_previous_value
       else
-        parameter_value.to_s
+        ParameterValue.new(parameter_value).to_param
+      end
+    end
+
+  end
+
+  class ParameterValue
+
+    def initialize(value)
+      @value = value
+    end
+
+    def to_param
+      case @value
+      when TrueClass, FalseClass, Integer then
+        @value.to_s
+      when Array
+        @value.map { |v| ParameterValue.new(v).to_param }.join(",")
+      else
+        @value
       end
     end
 

--- a/lib/stackup/parameters.rb
+++ b/lib/stackup/parameters.rb
@@ -45,7 +45,7 @@ module Stackup
           if value == :use_previous_value
             record[:use_previous_value] = true
           else
-            record[:parameter_value] = value
+            record[:parameter_value] = value.to_s
           end
         end
       end
@@ -75,7 +75,7 @@ module Stackup
       if use_previous_value
         :use_previous_value
       else
-        parameter_value
+        parameter_value.to_s
       end
     end
 

--- a/spec/stackup/parameters_spec.rb
+++ b/spec/stackup/parameters_spec.rb
@@ -146,6 +146,30 @@ describe Stackup::Parameters do
 
     end
 
+    context "with Integer values" do
+
+      let(:input_records) do
+        [{ :parameter_key => "SomeInteger", :parameter_value => 123_456_789 }]
+      end
+
+      subject(:parameters) { Stackup::Parameters.new(input_records) }
+
+      describe "#to_hash" do
+        it "converts the Integer to a String" do
+          expected = { "SomeInteger" => "123456789" }
+          expect(parameters.to_hash).to eql(expected)
+        end
+      end
+
+      describe "#to_a" do
+        it "converts the Integer to a String" do
+          expected = [{ :parameter_key => "SomeInteger", :parameter_value => "123456789" }]
+          expect(parameters.to_a).to eql(expected)
+        end
+      end
+
+    end
+
     context "with empty parameter file" do
 
       let(:input_records) { false }

--- a/spec/stackup/parameters_spec.rb
+++ b/spec/stackup/parameters_spec.rb
@@ -146,24 +146,45 @@ describe Stackup::Parameters do
 
     end
 
-    context "with Integer values" do
+    context "with non-string values" do
 
       let(:input_records) do
-        [{ :parameter_key => "SomeInteger", :parameter_value => 123_456_789 }]
+        [
+          { :parameter_key => "Integer", :parameter_value => 123_456_789 },
+          { :parameter_key => "Truthy", :parameter_value => true },
+          { :parameter_key => "Falsey", :parameter_value => false },
+          { :parameter_key => "Null", :parameter_value => nil },
+          { :parameter_key => "Array", :parameter_value => ["one", 2] },
+          { :parameter_key => "String", :parameter_value => "string" }
+        ]
       end
 
       subject(:parameters) { Stackup::Parameters.new(input_records) }
 
       describe "#to_hash" do
-        it "converts the Integer to a String" do
-          expected = { "SomeInteger" => "123456789" }
+        it "converts the to strings where appropriate" do
+          expected = {
+            "Integer" => "123456789",
+            "Truthy" => "true",
+            "Falsey" => "false",
+            "Null" => nil,
+            "Array" => "one,2",
+            "String" => "string"
+          }
           expect(parameters.to_hash).to eql(expected)
         end
       end
 
       describe "#to_a" do
-        it "converts the Integer to a String" do
-          expected = [{ :parameter_key => "SomeInteger", :parameter_value => "123456789" }]
+        it "converts the to strings where appropriate" do
+          expected = [
+            { :parameter_key => "Integer", :parameter_value => "123456789" },
+            { :parameter_key => "Truthy", :parameter_value => "true" },
+            { :parameter_key => "Falsey", :parameter_value => "false" },
+            { :parameter_key => "Null", :parameter_value => nil },
+            { :parameter_key => "Array", :parameter_value => "one,2" },
+            { :parameter_key => "String", :parameter_value => "string" }
+          ]
           expect(parameters.to_a).to eql(expected)
         end
       end


### PR DESCRIPTION
The ruby AWS SDK always expects string input. Even if your cloudformation parameter type is `Number`, it still wants it to be a ruby String. The validation of parameter value will happen in cloudformation land.

Currently stackup is just passing through the raw YAML value to the SDK as is - which means it is up to the caller to understand the nuances on the ruby AWS SDK (where everything must be a string). Given stackup is supposed to "help" reduce cognitive load, I think it's ok for it to help convert our YAML values in this instance.